### PR TITLE
Fix crash when trying to close a window when editor is empty.

### DIFF
--- a/UI/MainWindowCommands.cs
+++ b/UI/MainWindowCommands.cs
@@ -114,6 +114,7 @@ namespace Spcode.UI
         private void Command_Close()
         {
             var ee = GetCurrentEditorElement();
+            if (ee == null) return;
             DockingPane.RemoveChild(ee.Parent);
             ee.Close();
         }


### PR DESCRIPTION
When doing `Ctrl + W` and the editor is empty the program will crash.

This check prevents it.

Crash report:
[CRASH_3975890.txt](https://github.com/Hexer10/Spcode/files/5399526/CRASH_3975890.txt)
