### PR TITLE
#67 Bracket Highlighting Fixes

### DIFF
--- a/UI/Components/EditorElement.xaml
+++ b/UI/Components/EditorElement.xaml
@@ -74,7 +74,8 @@
         <CheckBox x:Name="CompileBox" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="2,0,0,0" Content="Compile" Foreground="{DynamicResource BlackColorBrush}" />
         <!-- <TextBlock Name="StatusLine_Work" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="100,0,0,0" Text="HERE" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" /> -->
         <TextBlock Name="StatusLine_FontSize" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2" Text="14 pt" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
-        <TextBlock Name="StatusLine_Column" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,100,2" Text="Col 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
+    <TextBlock Name="StatusLine_Column" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,100,2" Text="Col 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
+    <TextBlock Name="StatusLine_Offset" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,151,2" Text="Off 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
         <TextBlock Name="StatusLine_Line" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,200,2" Text="Ln 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
         <TextBlock Name="StatusLine_SelectionLength" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,300,2" Text="Len 0" Foreground="{DynamicResource BlackColorBrush}" />
         <Grid Name="ISAC_Grid" Opacity="0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="Auto" IsHitTestVisible="False">

--- a/UI/Components/EditorElement.xaml
+++ b/UI/Components/EditorElement.xaml
@@ -75,7 +75,7 @@
         <!-- <TextBlock Name="StatusLine_Work" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="100,0,0,0" Text="HERE" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" /> -->
         <TextBlock Name="StatusLine_FontSize" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2" Text="14 pt" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
     <TextBlock Name="StatusLine_Column" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,100,2" Text="Col 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
-    <TextBlock Name="StatusLine_Offset" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,151,2" Text="Off 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
+    <TextBlock Name="StatusLine_Offset" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,151,2" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
         <TextBlock Name="StatusLine_Line" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,200,2" Text="Ln 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
         <TextBlock Name="StatusLine_SelectionLength" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,300,2" Text="Len 0" Foreground="{DynamicResource BlackColorBrush}" />
         <Grid Name="ISAC_Grid" Opacity="0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="Auto" IsHitTestVisible="False">

--- a/UI/Components/EditorElement.xaml
+++ b/UI/Components/EditorElement.xaml
@@ -74,7 +74,7 @@
         <CheckBox x:Name="CompileBox" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="2,0,0,0" Content="Compile" Foreground="{DynamicResource BlackColorBrush}" />
         <!-- <TextBlock Name="StatusLine_Work" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="100,0,0,0" Text="HERE" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" /> -->
         <TextBlock Name="StatusLine_FontSize" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2" Text="14 pt" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
-        <TextBlock Name="StatusLine_Coloumn" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,100,2" Text="Col 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
+        <TextBlock Name="StatusLine_Column" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,100,2" Text="Col 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
         <TextBlock Name="StatusLine_Line" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,200,2" Text="Ln 0" Foreground="{DynamicResource BlackColorBrush}" IsHitTestVisible="False" />
         <TextBlock Name="StatusLine_SelectionLength" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="2,2,300,2" Text="Len 0" Foreground="{DynamicResource BlackColorBrush}" />
         <Grid Name="ISAC_Grid" Opacity="0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="Auto" IsHitTestVisible="False">

--- a/UI/Components/EditorElement.xaml.cs
+++ b/UI/Components/EditorElement.xaml.cs
@@ -780,8 +780,6 @@ namespace SPCode.UI.Components
             StatusLine_Line.Text = $"{Program.Translations.GetLanguage("LnAbb")} {editor.TextArea.Caret.Line}";
 #if DEBUG
             StatusLine_Offset.Text = $"Off {editor.TextArea.Caret.Offset}";
-#else
-            StatusLine_Offset.Text = "";
 #endif
             EvaluateIntelliSense();
 

--- a/UI/Components/EditorElement.xaml.cs
+++ b/UI/Components/EditorElement.xaml.cs
@@ -778,6 +778,11 @@ namespace SPCode.UI.Components
         {
             StatusLine_Column.Text = $"{Program.Translations.GetLanguage("ColAbb")} {editor.TextArea.Caret.Column}";
             StatusLine_Line.Text = $"{Program.Translations.GetLanguage("LnAbb")} {editor.TextArea.Caret.Line}";
+#if DEBUG
+            StatusLine_Offset.Text = $"Off {editor.TextArea.Caret.Offset}";
+#else
+            StatusLine_Offset.Text = "";
+#endif
             EvaluateIntelliSense();
 
             var result = bracketSearcher.SearchBracket(editor.Document, editor.CaretOffset);

--- a/UI/Components/EditorElement.xaml.cs
+++ b/UI/Components/EditorElement.xaml.cs
@@ -776,12 +776,12 @@ namespace SPCode.UI.Components
 
         private void Caret_PositionChanged(object sender, EventArgs e)
         {
-            StatusLine_Coloumn.Text = $"{Program.Translations.GetLanguage("ColAbb")} {editor.TextArea.Caret.Column}";
+            StatusLine_Column.Text = $"{Program.Translations.GetLanguage("ColAbb")} {editor.TextArea.Caret.Column}";
             StatusLine_Line.Text = $"{Program.Translations.GetLanguage("LnAbb")} {editor.TextArea.Caret.Line}";
             EvaluateIntelliSense();
+
             var result = bracketSearcher.SearchBracket(editor.Document, editor.CaretOffset);
             bracketHighlightRenderer.SetHighlight(result);
-
 
             if (!Program.OptionsObject.Program_DynamicISAC || Program.MainWindow == null)
             {
@@ -1187,7 +1187,7 @@ namespace SPCode.UI.Components
             CompileBox.Content = Program.Translations.GetLanguage("Compile");
             if (!Initial)
             {
-                StatusLine_Coloumn.Text =
+                StatusLine_Column.Text =
                     $"{Program.Translations.GetLanguage("ColAbb")} {editor.TextArea.Caret.Column}";
                 StatusLine_Line.Text = $"{Program.Translations.GetLanguage("LnAbb")} {editor.TextArea.Caret.Line}";
                 StatusLine_FontSize.Text =

--- a/UI/Components/EditorElementBracketHighlighter.cs
+++ b/UI/Components/EditorElementBracketHighlighter.cs
@@ -691,7 +691,6 @@ namespace SPCode.UI.Components
             for (var i = offset; i >= 0; --i)
             {
                 var ch = document.GetCharAt(i);
-                var c = document.GetLineByOffset(i);
 
                 // If we find a quote in the same line, set a flag.
                 

--- a/UI/Components/EditorElementBracketHighlighter.cs
+++ b/UI/Components/EditorElementBracketHighlighter.cs
@@ -60,6 +60,7 @@ namespace SPCode.UI.Components
     {
         BracketSearchResult SearchBracket(IDocument document, int offset);
     }
+
     public class BracketSearchResult
     {
         public int OpeningBracketOffset { get; private set; }
@@ -86,11 +87,15 @@ namespace SPCode.UI.Components
 
     public class SPBracketSearcher : IBracketSearcher
     {
+        #region Variables
         private readonly string openingBrackets = "([{";
         private readonly string closingBrackets = ")]}";
         private bool isCommentBlockForward;
         private bool isCommentBlockBackward;
         private bool isCommentLine;
+        private bool isString;
+        private bool isChar;
+        #endregion
 
         public BracketSearchResult SearchBracket(IDocument document, int offset)
         {
@@ -227,141 +232,7 @@ namespace SPCode.UI.Components
         }
         #endregion
 
-        #region SearchBracketBackward
-        private int SearchBracketBackward(IDocument document, int offset, char openBracket, char closingBracket)
-        {
-            if (offset + 1 >= document.TextLength)
-            {
-                return -1;
-            }
-
-            var quickResult = QuickSearchBracketBackward(document, offset, openBracket, closingBracket);
-            isCommentBlockBackward = CheckForCommentBackward(document, offset, openBracket, closingBracket);
-            isCommentLine = CheckForCommentLine(document, offset);
-
-            if (quickResult >= 0 && !isCommentBlockBackward && !isCommentLine)
-            {
-                return quickResult;
-            }
-
-            var linestart = ScanLineStart(document, offset + 1);
-
-            var starttype = GetStartType(document, linestart, offset + 1);
-            if (starttype == 1)
-            {
-                return -1;
-            }
-            var bracketStack = new Stack<int>();
-            var blockComment = false;
-            var lineComment = false;
-            var inChar = false;
-            var inString = false;
-            var verbatim = false;
-
-            for (var i = 0; i <= offset; ++i)
-            {
-                var ch = document.GetCharAt(i);
-                switch (ch)
-                {
-                    case '\r':
-                    case '\n':
-                        lineComment = false;
-                        inChar = false;
-                        if (!verbatim)
-                        {
-                            inString = false;
-                        }
-
-                        break;
-                    case '/':
-                        if (blockComment)
-                        {
-                            if (document.GetCharAt(i - 1) == '*')
-                            {
-                                blockComment = false;
-                            }
-                        }
-                        if (!inString && !inChar && i + 1 < document.TextLength)
-                        {
-                            if (!blockComment && document.GetCharAt(i + 1) == '/')
-                            {
-                                lineComment = true;
-                            }
-                            if (!lineComment && document.GetCharAt(i + 1) == '*')
-                            {
-                                blockComment = true;
-                            }
-                        }
-                        break;
-                    case '"':
-                        if (!(inChar || lineComment || blockComment))
-                        {
-                            if (inString && verbatim)
-                            {
-                                if (i + 1 < document.TextLength && document.GetCharAt(i + 1) == '"')
-                                {
-                                    ++i; // skip escaped quote
-                                    inString = false; // let the string go
-                                }
-                                else
-                                {
-                                    verbatim = false;
-                                }
-                            }
-                            else if (i > 0) //FIX CRASH ON SELECTING
-                            {
-                                if (!inString && offset > 0 && document.GetCharAt(i - 1) == '@')
-                                {
-                                    verbatim = true;
-                                }
-                            }
-                            inString = !inString;
-                        }
-                        break;
-                    case '\'':
-                        if (!(inString || lineComment || blockComment))
-                        {
-                            inChar = !inChar;
-                        }
-                        break;
-                    case '\\':
-                        if ((inString && !verbatim) || inChar)
-                        {
-                            ++i;
-                        }
-
-                        break;
-                    default:
-                        if (ch == openBracket)
-                        {
-                            if (!(inString || inChar || lineComment || blockComment || isCommentBlockBackward || isCommentLine))
-                            {
-                                bracketStack.Push(i);
-                            }
-                        }
-                        else if (ch == closingBracket)
-                        {
-                            if (!(inString || inChar || lineComment || blockComment))
-                            {
-                                if (bracketStack.Count > 0)
-                                {
-                                    bracketStack.Pop();
-                                }
-                            }
-                        }
-                        break;
-                }
-            }
-            if (bracketStack.Count > 0)
-            {
-                return bracketStack.Pop();
-            }
-
-            return -1;
-        }
-        #endregion
-
-        #region SearchBracketForward
+        #region Bracket Searchers
         private int SearchBracketForward(IDocument document, int offset, char openBracket, char closingBracket)
         {
             var inString = false;
@@ -376,14 +247,24 @@ namespace SPCode.UI.Components
                 return -1;
             }
 
+            // After searching for quick result, we check for
+            // comment blocks, comment lines, string and chars
+
             var quickResult = QuickSearchBracketForward(document, offset, openBracket, closingBracket);
             isCommentBlockForward = CheckForCommentBlockForward(document, offset);
             isCommentLine = CheckForCommentLine(document, offset);
+            isString = CheckForString(document, offset);
+            isChar = CheckForChar(document, offset);
 
-            if (quickResult >= 0 && !isCommentBlockForward && !isCommentLine)
+            // If the Quick Search result is valid, only return it if we determined the bracket
+            // is valid (is not inside a comment block, comment line, string or char)
+
+            if (quickResult >= 0 && !isCommentBlockForward && !isCommentLine && !isString && !isChar)
             {
                 return quickResult;
             }
+
+            // Otherwise, scan normally (not sure how it's done, I need to review and add further comments)
 
             var linestart = ScanLineStart(document, offset);
 
@@ -475,7 +356,7 @@ namespace SPCode.UI.Components
                         }
                         else if (ch == closingBracket)
                         {
-                            if (!(inString || inChar || lineComment || blockComment || isCommentBlockForward || isCommentLine))
+                            if (!(inString || inChar || lineComment || blockComment || isCommentBlockForward || isCommentLine || isString || isChar))
                             {
                                 --brackets;
                                 if (brackets == 0)
@@ -490,8 +371,151 @@ namespace SPCode.UI.Components
             }
             return -1;
         }
+
+        private int SearchBracketBackward(IDocument document, int offset, char openBracket, char closingBracket)
+        {
+            if (offset + 1 >= document.TextLength)
+            {
+                return -1;
+            }
+
+            // After searching for quick result, we check for
+            // comment blocks, comment lines, string and chars
+
+            var quickResult = QuickSearchBracketBackward(document, offset, openBracket, closingBracket);
+            isCommentBlockBackward = CheckForCommentBackward(document, offset, openBracket, closingBracket);
+            isCommentLine = CheckForCommentLine(document, offset);
+            isString = CheckForString(document, offset);
+            isChar = CheckForChar(document, offset);
+
+            // If the Quick Search result is valid, only return it if we determined the bracket
+            // is valid (is not inside a comment block, comment line, string or char)
+
+            if (quickResult >= 0 && !isCommentBlockBackward && !isCommentLine && !isString && !isChar)
+            {
+                return quickResult;
+            }
+
+            // Otherwise, scan normally (not sure how it's done, I need to review and add further comments)
+
+            var linestart = ScanLineStart(document, offset + 1);
+
+            var starttype = GetStartType(document, linestart, offset + 1);
+            if (starttype == 1)
+            {
+                return -1;
+            }
+            var bracketStack = new Stack<int>();
+            var blockComment = false;
+            var lineComment = false;
+            var inChar = false;
+            var inString = false;
+            var verbatim = false;
+
+            for (var i = 0; i <= offset; ++i)
+            {
+                var ch = document.GetCharAt(i);
+                switch (ch)
+                {
+                    case '\r':
+                    case '\n':
+                        lineComment = false;
+                        inChar = false;
+                        if (!verbatim)
+                        {
+                            inString = false;
+                        }
+
+                        break;
+                    case '/':
+                        if (blockComment)
+                        {
+                            if (document.GetCharAt(i - 1) == '*')
+                            {
+                                blockComment = false;
+                            }
+                        }
+                        if (!inString && !inChar && i + 1 < document.TextLength)
+                        {
+                            if (!blockComment && document.GetCharAt(i + 1) == '/')
+                            {
+                                lineComment = true;
+                            }
+                            if (!lineComment && document.GetCharAt(i + 1) == '*')
+                            {
+                                blockComment = true;
+                            }
+                        }
+                        break;
+                    case '"':
+                        if (!(inChar || lineComment || blockComment))
+                        {
+                            if (inString && verbatim)
+                            {
+                                if (i + 1 < document.TextLength && document.GetCharAt(i + 1) == '"')
+                                {
+                                    ++i; // skip escaped quote
+                                    inString = false; // let the string go
+                                }
+                                else
+                                {
+                                    verbatim = false;
+                                }
+                            }
+                            else if (i > 0) //FIX CRASH ON SELECTING
+                            {
+                                if (!inString && offset > 0 && document.GetCharAt(i - 1) == '@')
+                                {
+                                    verbatim = true;
+                                }
+                            }
+                            inString = !inString;
+                        }
+                        break;
+                    case '\'':
+                        if (!(inString || lineComment || blockComment))
+                        {
+                            inChar = !inChar;
+                        }
+                        break;
+                    case '\\':
+                        if ((inString && !verbatim) || inChar)
+                        {
+                            ++i;
+                        }
+
+                        break;
+                    default:
+                        if (ch == openBracket)
+                        {
+                            if (!(inString || inChar || lineComment || blockComment || isCommentBlockBackward || isCommentLine || isString || isChar))
+                            {
+                                bracketStack.Push(i);
+                            }
+                        }
+                        else if (ch == closingBracket)
+                        {
+                            if (!(inString || inChar || lineComment || blockComment))
+                            {
+                                if (bracketStack.Count > 0)
+                                {
+                                    bracketStack.Pop();
+                                }
+                            }
+                        }
+                        break;
+                }
+            }
+            if (bracketStack.Count > 0)
+            {
+                return bracketStack.Pop();
+            }
+
+            return -1;
+        }
         #endregion
 
+        #region Quick Search Helpers
         private int QuickSearchBracketBackward(IDocument document, int offset, char openBracket, char closingBracket)
         {
             var brackets = -1;
@@ -585,7 +609,8 @@ namespace SPCode.UI.Components
             {
                 var ch = document.GetCharAt(i);
 
-                // If we find the characters ' */ ' together, it means a comment block is finishing
+                // If we find the characters ' */ ' together scanning forward, 
+                // it means a comment block is finishing
                 // therefore, we've been inside a code block this whole time:
                 // this bracket should be ignored by the highlighter
 
@@ -594,7 +619,9 @@ namespace SPCode.UI.Components
                     return true;
                 }
 
-                // If we find, however, ' /* ', a code block is starting - I'll try and return false on this one
+                // If we find, however, ' /* ', a code block is starting:
+                // not possible that we've been in a comment block
+                // that's a nested comment compiling error
 
                 if (ch == '/' && document.GetCharAt(i + 1) == '*')
                 {
@@ -611,7 +638,8 @@ namespace SPCode.UI.Components
             {
                 var ch = document.GetCharAt(i);
 
-                // If we find the characters ' /* ' together (backwards speaking), it means a comment block is starting
+                // If we find the characters ' /* ' together while scanning backwards, 
+                // it means a comment block is starting
                 // therefore, we've been inside a code block this whole time:
                 // this bracket should be ignored by the highlighter
 
@@ -620,9 +648,11 @@ namespace SPCode.UI.Components
                     return true;
                 }
 
-                // If we find, however, ' /* ', a code block is finishing - I'll try and return false on this one
+                // If we find, however, ' /* ', a code block is finishing:
+                // not possible that we've been in a comment block
+                // that's a nested comment compiling error
 
-                if (ch == '/' && document.GetCharAt(i - 1) == '*')
+                if (ch == '/' && i > 0 && document.GetCharAt(i - 1) == '*')
                 {
                     return false;
                 }
@@ -637,10 +667,15 @@ namespace SPCode.UI.Components
             {
                 var ch = document.GetCharAt(i);
 
+                // If we find two ' // ' together as we scan backwards
+                // we find we are in a comment line, and should ignore the bracket
+
                 if (ch == '/' && document.GetCharAt(i - 1) == '/')
                 {
                     return true;
                 }
+
+                // If the next scanned character is a newline, cut the function off
 
                 if (ch == '\n')
                 {
@@ -649,5 +684,94 @@ namespace SPCode.UI.Components
             }
             return false;
         }
+
+        private bool CheckForString(IDocument document, int offset)
+        {
+            var quoteFound = false;
+            for (var i = offset; i >= 0; --i)
+            {
+                var ch = document.GetCharAt(i);
+                var c = document.GetLineByOffset(i);
+
+                // If we find a quote in the same line, set a flag.
+                
+                if (ch == '"')
+                {
+                    quoteFound = true;
+                }
+
+                // Otherwise, keep looking for a line jump and a '\'
+                // to cover the case of its usage to escape the newline
+
+                if (ch == '\n' && i > 0)
+                {
+                    if (document.GetCharAt(i - 1) == '\r' && document.GetCharAt(i - 2) == '\\')
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            // If there was an opening quote, look forward for the closing quote
+            // skipping the combination of a backslash and a newline
+
+            if (quoteFound)
+            {
+                for (var i = offset; i < document.TextLength; ++i)
+                {
+                    var ch = document.GetCharAt(i);
+                    if (ch == '"')
+                    {
+                        return true;
+                    }
+
+                    if (ch == '\\' && document.GetCharAt(i + 1) == '\r')
+                    {
+                        continue;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private bool CheckForChar(IDocument document, int offset)
+        {
+            var apFound = false;
+            for (var i = offset; i >= 0; --i)
+            {
+                var ch = document.GetCharAt(i);
+
+                // Scanning backwards, if we find the apostrophe, set the flag
+
+                if (ch == '\'')
+                {
+                    apFound = true;
+                }
+            }
+            if (apFound)
+            {
+                for (var i = offset; i < document.TextLength; ++i)
+                {
+                    var ch = document.GetCharAt(i);
+
+                    // If the flag is true, scan for the other one
+
+                    if (ch == '\'')
+                    {
+                        return true;
+                    }
+                    if (ch == '\n')
+                    {
+                        break;
+                    }
+                }
+            }
+            return false;
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
I managed to fix the issue described at the issue's title (#67), but other things came along the way:
I found out this happens also inside strings and inside apostrophes (the ones used for enclosing chars), for which I did not have a clear path for fixing.
Also I think the solutions presented here are terribly unoptimized, code-wise and performance-wise, but who knows, it's what I came up with at the time.