### PR TITLE
New 'New' functionality + 'New From Template'.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -111,7 +111,7 @@ csharp_style_prefer_index_operator = true:suggestion
 csharp_style_prefer_range_operator = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_style_unused_value_expression_statement_preference = discard_variable:none
 
 # 'using' directive preferences
 csharp_using_directive_placement = outside_namespace:suggestion
@@ -204,3 +204,6 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# IDE0058: Expression value is never used
+dotnet_diagnostic.IDE0058.severity = none

--- a/Interop/TranslationProvider.cs
+++ b/Interop/TranslationProvider.cs
@@ -140,6 +140,7 @@ namespace SPCode.Interop
             language.Add("Done", "Done");
             language.Add("FileStr", "File");
             language.Add("New", "New");
+            language.Add("NewFromTemplate", "New From Template");
             language.Add("Open", "Open");
             language.Add("Save", "Save");
             language.Add("SaveAll", "Save all");

--- a/Resources/lang_0_spcode_entryTemplate.xml
+++ b/Resources/lang_0_spcode_entryTemplate.xml
@@ -45,6 +45,7 @@
 	<done>done</done>
 	<file>File</file>
 	<new>New</new>
+	<newfromtemplate>New From Template</newfromtemplate>
 	<open>Open</open>
 	<save>Save</save>
 	<saveall>Save all</saveall>

--- a/UI/MainWindow.xaml
+++ b/UI/MainWindow.xaml
@@ -55,6 +55,7 @@
             <Menu>
                 <MenuItem Name="MenuI_File" Header="File" SubmenuOpened="FileMenu_Open">
                     <MenuItem Name="MenuI_New" Header="New" Click="Menu_New" InputGestureText="Ctrl+N" />
+                    <MenuItem Name="MenuI_NewFromTemplate" Header="New From Template" Click="Menu_NewFromTemplate" InputGestureText="Ctrl+Shift+N" />
                     <MenuItem Name="MenuI_Open" Header="Open" Click="Menu_Open" InputGestureText="Ctrl+O" />
                     <Separator />
                     <MenuItem Name="MenuI_Save" Header="Save" Click="Menu_Save" InputGestureText="Ctrl+S" />

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -204,10 +204,8 @@ namespace SPCode.UI
             layoutDocument.Content = editor;
             EditorsReferences.Add(editor);
             DockingPane.Children.Add(layoutDocument);
-            if (SelectMe)
-            {
-                layoutDocument.IsSelected = true;
-            }
+            layoutDocument.IsSelected = SelectMe;
+            editor.editor.TextArea.Caret.Show();
         }
 
         private void DockingManager_ActiveContentChanged(object sender, EventArgs e)

--- a/UI/MainWindowCommands.cs
+++ b/UI/MainWindowCommands.cs
@@ -49,12 +49,12 @@ namespace SPCode.UI
             int newFileNum = 0;
             do
             {
-                newFilePath = Path.Combine(Program.Configs[Program.SelectedConfig].SMDirectories[0], $"new {++newFileNum}.sp");
+                newFilePath = Path.Combine(Program.Configs[Program.SelectedConfig].SMDirectories[0], $"New Plugin ({++newFileNum}).sp");
             } while (File.Exists(newFilePath));
-            
+
             File.Create(newFilePath).Close();
 
-            AddEditorElement(newFilePath, $"new {newFileNum}.sp", true);
+            AddEditorElement(newFilePath, $"New Plugin ({newFileNum}).sp", true);
         }
 
         private void Command_NewFromTemplate()
@@ -494,7 +494,7 @@ namespace SPCode.UI
                 Process.Start(OutFile);
                 await this.ShowMessageAsync(
                     Program.Translations.GetLanguage("JavaOpened"),
-                    Program.Translations.GetLanguage("JavaSuggestRestart"), 
+                    Program.Translations.GetLanguage("JavaSuggestRestart"),
                     MessageDialogStyle.Affirmative);
             }
             else
@@ -502,7 +502,7 @@ namespace SPCode.UI
                 // Otherwise, just offer a manual download
                 if (await this.ShowMessageAsync(
                     Program.Translations.GetLanguage("JavaDownErrorTitle"),
-                    Program.Translations.GetLanguage("JavaDownErrorMessage"), 
+                    Program.Translations.GetLanguage("JavaDownErrorMessage"),
                     MessageDialogStyle.AffirmativeAndNegative, MetroDialogOptions) == MessageDialogResult.Affirmative)
                 {
                     Process.Start(new ProcessStartInfo

--- a/UI/MainWindowCommands.cs
+++ b/UI/MainWindowCommands.cs
@@ -45,6 +45,20 @@ namespace SPCode.UI
 
         private void Command_New()
         {
+            string newFilePath;
+            int newFileNum = 0;
+            do
+            {
+                newFilePath = Path.Combine(Program.Configs[Program.SelectedConfig].SMDirectories[0], $"new {++newFileNum}.sp");
+            } while (File.Exists(newFilePath));
+            
+            File.Create(newFilePath).Close();
+
+            AddEditorElement(newFilePath, $"new {newFileNum}.sp", true);
+        }
+
+        private void Command_NewFromTemplate()
+        {
             var nfWindow = new NewFileWindow { Owner = this, ShowInTaskbar = false };
             nfWindow.ShowDialog();
         }

--- a/UI/MainWindowInputHandler.cs
+++ b/UI/MainWindowInputHandler.cs
@@ -38,6 +38,12 @@ namespace SPCode.UI
                 {
                     switch (e.Key)
                     {
+                        case Key.N:
+                            {
+                                Command_NewFromTemplate();
+                                e.Handled = true;
+                                break;
+                            }
                         case Key.S:
                             {
                                 Command_SaveAll();

--- a/UI/MainWindowMenuHandler.cs
+++ b/UI/MainWindowMenuHandler.cs
@@ -22,16 +22,21 @@ namespace SPCode.UI
             }
 
             var EditorIsSelected = GetCurrentEditorElement() != null;
-            ((MenuItem)((MenuItem)sender).Items[3]).IsEnabled = EditorIsSelected;
-            ((MenuItem)((MenuItem)sender).Items[5]).IsEnabled = EditorIsSelected;
-            ((MenuItem)((MenuItem)sender).Items[7]).IsEnabled = EditorIsSelected;
-            ((MenuItem)((MenuItem)sender).Items[4]).IsEnabled = EditorsAreOpen;
-            ((MenuItem)((MenuItem)sender).Items[8]).IsEnabled = EditorsAreOpen;
+            ((MenuItem)((MenuItem)sender).Items[4]).IsEnabled = EditorIsSelected;
+            ((MenuItem)((MenuItem)sender).Items[6]).IsEnabled = EditorIsSelected;
+            ((MenuItem)((MenuItem)sender).Items[8]).IsEnabled = EditorIsSelected;
+            ((MenuItem)((MenuItem)sender).Items[5]).IsEnabled = EditorsAreOpen;
+            ((MenuItem)((MenuItem)sender).Items[9]).IsEnabled = EditorsAreOpen;
         }
 
         private void Menu_New(object sender, RoutedEventArgs e)
         {
             Command_New();
+        }
+
+        private void Menu_NewFromTemplate(object sender, RoutedEventArgs e)
+        {
+            Command_NewFromTemplate();
         }
 
         private void Menu_Open(object sender, RoutedEventArgs e)

--- a/UI/MainWindowTranslations.cs
+++ b/UI/MainWindowTranslations.cs
@@ -29,6 +29,7 @@ namespace SPCode.UI
             }
             MenuI_File.Header = Program.Translations.GetLanguage("FileStr");
             MenuI_New.Header = Program.Translations.GetLanguage("New");
+            MenuI_NewFromTemplate.Header = Program.Translations.GetLanguage("NewFromTemplate");
             MenuI_Open.Header = Program.Translations.GetLanguage("Open");
             MenuI_Save.Header = Program.Translations.GetLanguage("Save");
             MenuI_SaveAll.Header = Program.Translations.GetLanguage("SaveAll");

--- a/UI/Windows/NewFileWindow.xaml
+++ b/UI/Windows/NewFileWindow.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              Width="800" Height="500" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" GlowBrush="{DynamicResource AccentColorBrush}"
-                      Title="New" ShowTitleBar="False">
+                      Title="New" ShowTitleBar="False" KeyDown="MetroWindow_KeyDown">
     <controls:MetroWindow.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/UI/Windows/NewFileWindow.xaml.cs
+++ b/UI/Windows/NewFileWindow.xaml.cs
@@ -13,7 +13,7 @@ using SPCode.Utils;
 namespace SPCode.UI.Windows
 {
     /// <summary>
-    ///     Interaction logic for AboutWindow.xaml
+    /// Interaction logic for NewFileWindow.xaml
     /// </summary>
     public partial class NewFileWindow
     {
@@ -182,6 +182,14 @@ namespace SPCode.UI.Windows
             }
         }
 
+        private void MetroWindow_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
+            }
+        }
+
         private void GoToSelectedTemplate()
         {
             var destFile = new FileInfo(PathBox.Text);
@@ -190,6 +198,7 @@ namespace SPCode.UI.Windows
             Program.MainWindow.TryLoadSourceFile(destFile.FullName, true, true, true);
             Close();
         }
+
     }
 
     public class TemplateInfo


### PR DESCRIPTION
This PR moves the functionality of the `New` button to a button called `New From Template` and adds a new `New` functionality that opens an empty file.

Input gestures:

`New`: `Ctrl + N`
`New From Template`: `Ctrl + Shift + N`

Closes #89